### PR TITLE
Format geo json response

### DIFF
--- a/src/api/polygons.js
+++ b/src/api/polygons.js
@@ -6,7 +6,11 @@ export default ({ config, db }) =>
   resource({
     id: "polygons",
 
-    load: async ({ query: { bounds = "" } }, polygonQueryType, callback) => {
+    load: async (
+      { query: { bounds = "", limit = "50" } },
+      polygonQueryType,
+      callback
+    ) => {
       const boundsArray = getBoundsArrayFromQuery({ queryBounds: bounds });
       const queryError = getLoadError({
         boundsArray,
@@ -17,10 +21,15 @@ export default ({ config, db }) =>
         const polygons = !queryError
           ? await polygonModel({ config, db }).getPolygonsByBounds({
               bounds: boundsArray,
-              queryType: polygonQueryType
+              queryType: polygonQueryType,
+              limit: parseInt(limit)
             })
           : [];
-        callback(queryError, polygons);
+        const geoJson = {
+          type: "FeatureCollection",
+          features: polygons
+        };
+        callback(queryError, geoJson);
       } catch (error) {
         console.error(error);
       }

--- a/src/api/polygons.js
+++ b/src/api/polygons.js
@@ -18,18 +18,14 @@ export default ({ config, db }) =>
       });
 
       try {
-        const polygons = !queryError
+        const geojson = !queryError
           ? await polygonModel({ config, db }).getPolygonsByBounds({
               bounds: boundsArray,
               queryType: polygonQueryType,
               limit: parseInt(limit)
             })
           : [];
-        const geoJson = {
-          type: "FeatureCollection",
-          features: polygons
-        };
-        callback(queryError, geoJson);
+        callback(queryError, geojson);
       } catch (error) {
         console.error(error);
       }

--- a/src/constants/open-street-maps.js
+++ b/src/constants/open-street-maps.js
@@ -1,0 +1,1 @@
+export const FEATURE_COLLECTION = "FeatureCollection";

--- a/src/lib/geojson.js
+++ b/src/lib/geojson.js
@@ -1,4 +1,5 @@
 import { DB_FIELDS } from "../constants/polygons";
+import { FEATURE_COLLECTION } from "../constants/open-street-maps";
 import { functionWithRequiredParams } from "./util";
 
 export const createGeoJson = ({ type, geometry, name, propertyType }) => ({
@@ -24,6 +25,6 @@ export const mapPolygonRecordToGeoJson = polygon =>
   });
 
 export const formatFeaturesToFeatureCollection = ({ features = [] }) => ({
-  type: "FeatureCollection",
+  type: FEATURE_COLLECTION,
   features
 });

--- a/src/lib/geojson.js
+++ b/src/lib/geojson.js
@@ -22,3 +22,8 @@ export const mapPolygonRecordToGeoJson = polygon =>
     name: polygon[DB_FIELDS.PROPERTIES_NAME],
     propertyType: polygon[DB_FIELDS.PROPERTIES_TYPE]
   });
+
+export const formatFeaturesToFeatureCollection = ({ features }) => ({
+  type: "FeatureCollection",
+  features
+});

--- a/src/lib/geojson.js
+++ b/src/lib/geojson.js
@@ -23,7 +23,7 @@ export const mapPolygonRecordToGeoJson = polygon =>
     propertyType: polygon[DB_FIELDS.PROPERTIES_TYPE]
   });
 
-export const formatFeaturesToFeatureCollection = ({ features }) => ({
+export const formatFeaturesToFeatureCollection = ({ features = [] }) => ({
   type: "FeatureCollection",
   features
 });

--- a/src/models/polygons.js
+++ b/src/models/polygons.js
@@ -3,7 +3,10 @@ import {
   POLYGON_QUERY_TYPES,
   DB_FIELDS
 } from "../constants/polygons";
-import { mapPolygonRecordToGeoJson } from "../lib/geojson";
+import {
+  mapPolygonRecordToGeoJson,
+  formatFeaturesToFeatureCollection
+} from "../lib/geojson";
 import { getSqlListOfPolygonTypes } from "../lib/polygons-api";
 
 export default ({ config, db }) => ({
@@ -11,7 +14,9 @@ export default ({ config, db }) => ({
     const dbResponse = await db.query(
       `SELECT * FROM ${polygonTableName} LIMIT ${limit}`
     );
-    return dbResponse.rows.map(mapPolygonRecordToGeoJson);
+    return formatFeaturesToFeatureCollection({
+      features: dbResponse.rows.map(mapPolygonRecordToGeoJson)
+    });
   },
   getPolygonByQueryType: async function({ queryType, limit = 50 }) {
     if (queryType === POLYGON_QUERY_TYPES.ALL)
@@ -24,7 +29,9 @@ export default ({ config, db }) => ({
         DB_FIELDS.PROPERTIES_TYPE
       } IN (${dbTypesToQuery}) LIMIT ${limit}`
     );
-    return dbResponse.rows.map(mapPolygonRecordToGeoJson);
+    return formatFeaturesToFeatureCollection({
+      features: dbResponse.rows.map(mapPolygonRecordToGeoJson)
+    });
   },
   getPolygonsByBounds: async ({
     bounds,
@@ -60,6 +67,8 @@ export default ({ config, db }) => ({
     `;
 
     const dbResponse = await db.query(query);
-    return dbResponse.rows.map(mapPolygonRecordToGeoJson);
+    return formatFeaturesToFeatureCollection({
+      features: dbResponse.rows.map(mapPolygonRecordToGeoJson)
+    });
   }
 });


### PR DESCRIPTION
The PR changes the bounds query to respond with the polygon features inside an object with type FeatureCollection. This allows us to pass the response directly into the map object with zero front-end manipulation