### PR TITLE
Added config for deployment to GCP

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -20,5 +20,4 @@ node_modules/
 src/
 .env
 .vscode/
-.gitignore
 cloud_sql_proxy

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,24 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Node.js dependencies:
+node_modules/
+
+#Dev files
+src/
+.env
+.vscode/
+.gitignore
+cloud_sql_proxy

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,9 @@
 .env.*
 !.env.sample
 /postgres/.env
+
+#Proxy
 cloud_sql_proxy
+
+#Production config
+app.yaml

--- a/README.md
+++ b/README.md
@@ -21,4 +21,8 @@
 2.  Run command `yarn dev` or `npm run dev`
 
 ###Deployment:
-No current setup
+App deployment is done through the glcoud sdk.
+Once signed in to the gcp account you can run the following commands:
+
+1.  `yarn deploy` - Deploys new version of app to gcp app engine
+2.  `yarn browse` - Will open app in browser

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint src",
     "gcp-proxy": "./cloud_sql_proxy -instances=polyserv-api:us-central1:og-instance=tcp:5432",
     "deploy": "gcloud app deploy",
-    "open-in-web": "gcloud app browse"
+    "browse": "gcloud app browse"
   },
   "eslintConfig": {
     "extends": "eslint:recommended",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "start": "node dist",
     "prestart": "yarn run -s build",
     "lint": "eslint src",
-    "gcp-proxy": "./cloud_sql_proxy -instances=polyserv-api:us-central1:og-instance=tcp:5432"
+    "gcp-proxy": "./cloud_sql_proxy -instances=polyserv-api:us-central1:og-instance=tcp:5432",
+    "deploy": "gcloud app deploy",
+    "open-in-web": "gcloud app browse"
   },
   "eslintConfig": {
     "extends": "eslint:recommended",


### PR DESCRIPTION
The app.yaml file is available upon request, it contains env variables so not committing it to github

Requires you to be logged in through gcloud cli to use commands